### PR TITLE
Fixes & Enhancements

### DIFF
--- a/class.pmpro_posts_by_content.php
+++ b/class.pmpro_posts_by_content.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Created by Thomas Sjolshagen at PMPro <thomas@eigthy20results.com>
+ * Copyright 2016 (c) - Stranger Studios, LLC
+ *
+ * Class pmpro_posts_by_content is based on code from:
+ * http://wordpress.stackexchange.com/questions/49549/how-to-get-posts-by-content/49556#49556
+ */
+class pmpro_posts_by_content
+{
+    protected static $content = '';
+    protected static $like = true;
+
+    /**
+     * Mapper function for get_posts() supporting extra arguments 'content' and 'like'
+     *
+     * @param 'content' => String w/optional wildcard ('%') for free values
+     * @param 'like' => true or false
+     *
+     * @return WP_Post
+     * @since .4
+     */
+    public static function get( $args )
+    {
+        if ( isset( $args['content'] ) ) {
+            // 'suppress_filters' is TRUE by default for the get_posts() function
+            // it needs to be FALSE if we need the 'WHERE' filter to work
+            $args['suppress_filters'] = false;
+            self::$content = $args['content'];
+            add_filter('posts_where', array(__CLASS__, 'where_filter'));
+        }
+
+        // isset( $args['like'] ) and self::$like = (bool) $like;
+        $posts = get_posts( $args);
+
+        error_log("pmpro_posts_by_content: " . print_r($posts, true));
+
+        return $posts;
+    }
+
+    public static function where_filter( $where )
+    {
+        remove_filter('posts_where', array(__CLASS__, 'where_filter'));
+
+        error_log("pmpro_posts_by_content: " . print_r( $where, true ));
+
+        global $wpdb;
+        $like = self::$like ? 'LIKE' : 'NOT LIKE';
+
+        $extra = $wpdb->prepare('%s', self::$content);
+
+        // reset variables
+        self::$content = '';
+        self::$like = true;
+
+        $new_where = "{$where} AND post_content {$like} {$extra}";
+        error_log("pmpro_posts_by_content: " . print_r($new_where, true));
+
+        return $new_where;
+    }
+}

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -123,7 +123,24 @@ function pmpro_membership_card_get_post_id()
 		
 	//look in options
 	$from_options = get_option("pmpro_membership_card_post_ids", array());		
-		
+
+	// Make this an array so we can check it.
+	if (!is_array($from_options) && !empty($from_options))
+		$from_options = array($from_options);
+
+	// check status of the stored posts ID(s) for the membership card(s).
+	if (is_array($from_options) && !empty($from_options))
+	{
+		foreach($from_options as $k => $mc_id)
+		{
+			$p = get_post($mc_id);
+
+			// remove any entry that isn't a published post/page
+			if (!in_array( $p->post_status, array('publish', 'private')))
+				unset($from_options[$k]);
+		}
+	}
+
 	if(!empty($from_options) && is_array($from_options))
 		$pmpro_membership_card_get_post_id = end($from_options);
 	elseif(!empty($from_options))
@@ -145,7 +162,6 @@ function pmpro_membership_card_get_post_id()
 		//look for a post with the shortcode in it
 		if(!empty($from_post_content))
 			$pmpro_membership_card_get_post_id = $from_post_content;
-
 	}
 
 	//didn't find anything

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -172,7 +172,21 @@ function pmpro_membership_card_get_post_id()
 	Use an option to track pages with the [pmpro_membership_card] shortcode.
 */
 function pmpro_membership_card_save_post($post_id)
-{	
+{
+	global $post;
+
+	if ( !isset( $post->post_type) )
+		return;
+
+	if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE )
+		return;
+
+	if ( wp_is_post_revision( $post_id ) !== false )
+		return;
+
+	if ( 'trash' == get_post_status( $post_id ) )
+		return;
+
 	$args = array(
 		'p' => $post_id,
 		'posts_per_page' => 1,

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -195,14 +195,14 @@ function pmpro_membership_card_save_post($post_id)
 	);
 
 	$posts = pmpro_posts_by_content::get($args);
-	$post = $posts[0];
+	$post = isset($posts[0]) ? $posts[0] : null;
 
 	$option = get_option("pmpro_membership_card_post_ids", array());
 	
 	if(empty($option))
 		$option = array();
 		
-	if(has_shortcode($post->post_content, "pmpro_membership_card") && in_array($post->post_status,  array('publish', 'private')) )
+	if(isset($post->post_content) && has_shortcode($post->post_content, "pmpro_membership_card") && in_array($post->post_status,  array('publish', 'private')) )
 		$option[$post_id] = $post_id;
 	else
 		unset($option[$post_id]);


### PR DESCRIPTION
ENH: Add class to locate a post/page based on content (i.e. a shortcode)
ENH: Use built-in shortcode search function `has_shortcode()`
ENH: Use `pmpro_posts_by_content::get()` to search/find. Uses WP_Query & includes support for WP caching
FIX: Include private as well as published posts/pages in searches for the page/post containing the member card shortcode
FIX: Didn't use valid WP_User object when adding `u=` query parameter.