### PR TITLE
Check for Admin user and if in Post

### DIFF
--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -56,10 +56,13 @@
 		<?php } ?>
 	}
 </style>
+<?php if ( null !== $pmpro_membership_card_user ) { ?>
 <a class="pmpro_a-print" href="javascript:window.print()">Print</a>
 <div class="pmpro_membership_card">
-	<?php 
-		$featured_image = wp_get_attachment_url( get_post_thumbnail_id($post->ID) ); 
+	<?php // Check if in a Post first
+		if ( $post->ID ) {
+			$featured_image = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) );
+		} 
 		if(function_exists("pmpro_getMemberStartDate"))
 			$since = pmpro_getMemberStartDate($pmpro_membership_card_user->ID);
 		else
@@ -195,4 +198,9 @@
 		</div>
 	</nav>
 </div> <!-- end #pmpro_membership_card -->
-	
+<?php
+} elseif ( current_user_can( 'manage_options' ) ) {
+	echo 'You\'re an administrator, you don\'t need a membership card.';
+} else {
+	echo 'You\'re an administrator,';
+}


### PR DESCRIPTION
Admin user's may not have a level set and likely to thrown an error. Echoing statement where the memberhsip card should be helps to understand what the code is underneath. Also, if shortcode is in a widget, it will render something, but with an error beacuse no Featured Image.

Issue: https://github.com/strangerstudios/pmpro-membership-card/issues/9