### PR TITLE
feat:  PMPro extra page setting + per-level card permission

### DIFF
--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -71,6 +71,13 @@ function pmpro_membership_card_wp()
 			wp_redirect(pmpro_url("levels"));
 			exit;
 		}
+		// check if membership cards are permitted for their membership level.
+		$pmpro_level = pmpro_getMembershipLevelForUser();
+		$pmpro_show_membership_card = get_option( 'pmpro_show_membership_card_for_level_' . $pmpro_level->id, 1 );
+		if ($pmpro_show_membership_card !== 1) {
+			wp_redirect( pmpro_url( 'account' ) );
+			exit;
+		}
 	}
 	else
 	{

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -431,3 +431,16 @@ function pmpro_membership_card_qr_code_class( $pmpro_membership_card_user, $prin
 	}
 }
 add_action( 'pmpro_membership_card-extra_classes', 'pmpro_membership_card_qr_code_class', 10, 4 );
+
+/**
+ * Add page setting for the frontend Membership Card page
+ */
+function pmpro_membership_card_extra_page_settings($pages) {
+	$pages['membership_card'] = array(
+		'title' 	=> 'Membership Card',
+		'content' => '[pmpro_membership_card]',
+		'hint' 		=> 'Include the shortcode [pmpro_membership_card].'
+	);
+	return $pages;
+}
+add_action( 'pmpro_extra_page_settings', 'pmpro_membership_card_extra_page_settings' );

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -446,10 +446,10 @@ add_action( 'pmpro_membership_card-extra_classes', 'pmpro_membership_card_qr_cod
  * Add page setting for the frontend Membership Card page
  */
 function pmpro_membership_card_extra_page_settings($pages) {
-	$pages['membership_card'] = array(
-		'title' 	=> 'Membership Card',
-		'content' => '[pmpro_membership_card]',
-		'hint' 		=> 'Include the shortcode [pmpro_membership_card].'
+		$pages['membership_card'] = array(
+			'title'   => __( 'Membership Card', 'pmpro-membership-card' ),
+			'content' => '[pmpro_membership_card]',
+			'hint'    => __( 'Include the shortcode [pmpro_membership_card].', 'pmpro-membership-card' ),
 	);
 	return $pages;
 }
@@ -480,14 +480,14 @@ function pmpro_membership_card_pmpro_membership_level_after_other_settings()
 		$pmpro_show_membership_card = 1;
 	}
 	?>
-	<h3 class="topborder">Membership Card Settings</h3>
+	<h3 class="topborder"><?php _e( 'Membership Card Settings', 'pmpro-membership-card' ); ?></h3>
 	<table>
 	<tbody class="form-table">
 		<tr>
-			<th scope="row" valign="top"><label for="pmpro_show_membership_card_for_level">Show Card</label></th>
+			<th scope="row" valign="top"><label for="pmpro_show_membership_card_for_level"><?php _e( 'Show Card', 'pmpro-membership-card' ); ?></label></th>
 			<td>
 				<input type="checkbox" id="pmpro_show_membership_card_for_level" name="pmpro_show_membership_card_for_level" value="1" <?php checked( $pmpro_show_membership_card, 1 ); ?> />
-				<label for="pmpro_show_membership_card_for_level">Check this to show the Membership Card for members of this level.</label>
+				<label for="pmpro_show_membership_card_for_level"><?php _e( 'Check this to show the Membership Card for members of this level.', 'pmpro-membership-card' ); ?></label>
 			</td>
 		</tr>
 	</tbody>

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -444,3 +444,44 @@ function pmpro_membership_card_extra_page_settings($pages) {
 	return $pages;
 }
 add_action( 'pmpro_extra_page_settings', 'pmpro_membership_card_extra_page_settings' );
+
+/**
+ * Save membership card permission when a level is added or updated.
+ */
+function pmpro_membership_card_pmpro_save_membership_level($level_id) {
+	if ( isset( $_REQUEST['pmpro_show_membership_card_for_level'] ) ) {
+		$pmpro_show_membership_card = intval( $_REQUEST['pmpro_show_membership_card_for_level'] );
+	} else {
+		$pmpro_show_membership_card = 0;
+	}
+	update_option( 'pmpro_show_membership_card_for_level_' . $level_id, $pmpro_show_membership_card );
+}
+add_action( 'pmpro_save_membership_level', 'pmpro_membership_card_pmpro_save_membership_level' );
+
+/**
+ * Add checkbox to permit membership cards for members of this level.
+ */
+function pmpro_membership_card_pmpro_membership_level_after_other_settings()
+{	
+	$level_id = intval( $_REQUEST['edit'] );
+	if ( $level_id > 0 ) {
+		$pmpro_show_membership_card = get_option( 'pmpro_show_membership_card_for_level_' . $level_id, 1 );
+	} else {
+		$pmpro_show_membership_card = 1;
+	}
+	?>
+	<h3 class="topborder">Membership Card Settings</h3>
+	<table>
+	<tbody class="form-table">
+		<tr>
+			<th scope="row" valign="top"><label for="pmpro_show_membership_card_for_level">Show Card</label></th>
+			<td>
+				<input type="checkbox" id="pmpro_show_membership_card_for_level" name="pmpro_show_membership_card_for_level" value="1" <?php checked( $pmpro_show_membership_card, 1 ); ?> />
+				<label for="pmpro_show_membership_card_for_level">Check this to show the Membership Card for members of this level.</label>
+			</td>
+		</tr>
+	</tbody>
+	</table>
+	<?php
+}
+add_action( 'pmpro_membership_level_after_other_settings', 'pmpro_membership_card_pmpro_membership_level_after_other_settings' );

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -77,8 +77,15 @@ function pmpro_membership_card_wp()
 		// check if membership cards are permitted for their membership level.
 		$pmpro_level = pmpro_getMembershipLevelForUser();
 		$pmpro_show_membership_card = get_option( 'pmpro_show_membership_card_for_level_' . $pmpro_level->id, 1 );
-		if ($pmpro_show_membership_card !== 1) {
-			wp_redirect( pmpro_url( 'account' ) );
+		if ( $pmpro_show_membership_card !== 1 ) {
+			wp_redirect(
+				apply_filters(
+					'pmpro_membership_card_account_url',
+					pmpro_url( 'account' ),
+					$pmpro_membership_card_user,
+					$pmpro_level
+				)
+			);
 			exit;
 		}
 	}

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -3,7 +3,7 @@
 Plugin Name: Paid Memberships Pro - Membership Card Add On
 Plugin URI: http://www.paidmembershipspro.com/wp/pmpro-membership-card/
 Description: Display a printable Membership Card for Paid Memberships Pro members or WP users.
-Version: 1.1.0
+Version: 1.0
 Author: Stranger Studios
 Author URI: http://www.strangerstudios.com
 Text Domain: pmpro-membership-card
@@ -11,7 +11,7 @@ Domain Path: /languages
 */
 
 // version constant
-define('PMPRO_MEMBERSHIP_CARD_VERSION', '1.1.0');
+define('PMPRO_MEMBERSHIP_CARD_VERSION', '1.0');
 
 function pmpro_membership_card_load_textdomain(){
 	load_plugin_textdomain( 'pmpro-membership-card', false, basename( dirname( __FILE__ ) ) . '/languages' ); 


### PR DESCRIPTION
This pull request adds a PMPro extra page setting:
![image](https://user-images.githubusercontent.com/958800/86442169-a5140a80-bd0d-11ea-8ee4-ddab112228be.png)

And the ability to enable or disable Membership Cards per membership level (defaulting to true):
![image](https://user-images.githubusercontent.com/958800/86442184-aba28200-bd0d-11ea-88de-b3f5e9fdb90d.png)
