### PR TITLE
PHP8 Fixes

### DIFF
--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -170,7 +170,7 @@ function pmpro_membership_card_get_post_id()
 		$posts = pmpro_posts_by_content::get( $args );
 
 
-		if ( is_array( $posts ) && !empty( $posts ) ) {
+		if ( ! empty( $posts ) && is_array( $posts ) ) {
 			$from_post_content = $posts[0]->ID;
 		}
 		

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -170,7 +170,7 @@ function pmpro_membership_card_get_post_id()
 		$posts = pmpro_posts_by_content::get( $args );
 
 
-		if ( is_array( $posts ) ) {
+		if ( is_array( $posts ) && !empty( $posts ) ) {
 			$from_post_content = $posts[0]->ID;
 		}
 		


### PR DESCRIPTION
[Errors] Upon activation. Navigate to Member Account, scroll to Member Links section. Link is broken.

`/srv/users/phptesting/apps/php8/public/wp-content/plugins/pmpro-membership-card/pmpro-membership-card.php on line 174<br>https://php8.jarrydlong.co.za/membership-account/?u=1"&gt;View and Print Membership Card`

This PR adds in a check if the post array is empty, don't use it. 

```
[02-Dec-2020 13:40:14 UTC] PHP Warning: Attempt to read property "ID" on null in /srv/users/phptesting-jarrydlong/apps/php8jarrydlong/public/wp-content/plugins/pmpro-membership-card/pmpro-membership-card.php on line 174
```