### PR TITLE
Recognize/Detect the membership card shortcode in all post types

### DIFF
--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -216,7 +216,7 @@ function pmpro_membership_card_save_post( $post_id ) {
 	$args = array(
 		'p' => $post_id,
 		'posts_per_page' => 1,
-		'post_type' => array( 'post', 'page'),
+		'post_type' => array_unique( array( 'post', 'page', $post->post_type ) ),
 		'post_status' => array('publish', 'private')
 	);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-signup-shortcode/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-signup-shortcode/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The plugin can't currently detect if there's a membership card shortcode being saved in a post that isn't a post or page. 

The suggested changes include the current post type of the post being edited to ensure its also considered.

Resolves #14

### How to test the changes in this Pull Request:

1. Use a CPT such as a course and add the membership card shortcode to it. 
2. Save it and navigate to the Membership Account page - the link will detect that the membership card belongs in that CPT.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Removed the 'Whats this' prompt next to the CVV field