### PR TITLE
Better print css sizing

### DIFF
--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -154,9 +154,9 @@
 		<?php if(!empty($print_large)) { ?>
 			.pmpro_membership_card-print-lg {
 				display: block;
-				height: 90mm;
+				height: 115mm;
 				overflow: hidden;
-				width: 143mm;
+				width: 185mm;
 				visibility: visible !important;
 			}
 			.pmpro_membership_card-print-lg .pmpro_membership_card-inner {
@@ -170,7 +170,7 @@
 			}
 			.pmpro_membership_card-print-lg img.pmpro_membership_card_image {
 				margin-bottom: 5mm;
-				max-width: 40mm !important;
+				max-width: 60mm !important;
 			}
 			.pmpro_membership_card-print.pmpro_membership_card-print-lg h1 {
 				font-size: 28pt;

--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -218,7 +218,7 @@
 					if(!empty($since))
 					{
 					?>
-					<p id="pmpro_membership_card_member_since"><strong><?php _e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo date_i18n(get_option("date_format"), strtotime($pmpro_membership_card_user->user_registered));?></p>
+					<p id="pmpro_membership_card_member_since"><strong><?php esc_html_e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo apply_filters('pmpro_membership_card_since_date', date_i18n( get_option("date_format"), strtotime( $pmpro_membership_card_user->user_registered ) ), $pmpro_membership_card_user );?></p>
 					<?php
 					}
 				?>
@@ -263,7 +263,7 @@
 					if(!empty($since))
 					{
 					?>
-					<p id="pmpro_membership_card_member_since"><strong><?php _e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo apply_filters('pmpro_membership_card_since_date', date_i18n( get_option("date_format"), strtotime( $pmpro_membership_card_user->user_registered ) ), $pmpro_membership_card_user );?></p>
+					<p id="pmpro_membership_card_member_since"><strong><?php esc_html_e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo apply_filters('pmpro_membership_card_since_date', date_i18n( get_option("date_format"), strtotime( $pmpro_membership_card_user->user_registered ) ), $pmpro_membership_card_user );?></p>
 					<?php
 					}
 				?>
@@ -309,7 +309,7 @@
 					if(!empty($since))
 					{
 					?>
-					<p id="pmpro_membership_card_member_since"><strong><?php _e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo date_i18n(get_option("date_format"), strtotime($pmpro_membership_card_user->user_registered));?></p>
+					<p id="pmpro_membership_card_member_since"><strong><?php esc_html_e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo apply_filters('pmpro_membership_card_since_date', date_i18n(get_option("date_format"), strtotime($pmpro_membership_card_user->user_registered)));?></p>
 					<?php
 					}
 				?>
@@ -345,4 +345,3 @@
 		</div>
 	</nav>
 </div> <!-- end #pmpro_membership_card -->
-	

--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -21,44 +21,171 @@
 	/* Hide any thumbnail that might be on the page. */
 	.page .attachment-post-thumbnail, .page .wp-post-image {display: none;}
 	.post .attachment-post-thumbnail, .post .wp-post-image {display: none;}
-	
+
 	/* Page Styles */
-	.pmpro_membership_card {clear: both;}
-	.pmpro_membership_card-print {background: #FFF; border: 1px solid #000000; -webkit-border-radius: 10px; -moz-border-radius: 10px; border-radius: 10px; margin: 0 0 20px 0;}
-	.pmpro_membership_card-inner {padding: 5%;}
-	.pmpro_membership_card-print h1 {font-size: 28px; margin: 0 0 10px 0;}
-	.pmpro_membership_card-print p {font-size: 12px; margin: 10px 0 0 0; padding: 0;}
-	img.pmpro_membership_card_image {border: none; box-shadow: none; float: right;}
-	.pmpro_membership_card-print-md .pmpro_membership_card_image {max-width: 150px;}
-	.pmpro_membership_card-print-md img.pmpro_membership_card_image {margin-bottom: 5%;}
-	.pmpro_membership_card-print-sm, .pmpro_membership_card-print-lg {display: none; visibility: hidden !important;}
-	.pmpro_clear {clear: both;}
-	.pmpro_membership_card-inner.qr_code_active .pmpro_membership_card-data, .pmpro_membership_card-inner.qr_code_active .pmpro_membership_card-after { width: 48%; display: inline-block; vertical-align: middle; }
-	.pmpro_membership_card-inner.qr_code_active .pmpro_membership_card-after{ margin-left: 2%; }
+	.pmpro_membership_card {
+		clear: both;
+	}
+	.pmpro_membership_card-print {
+		background: #FFF;
+		border: 1px solid #000000;
+		border-radius: 10px;
+		margin: 0 0 20px 0;
+	}
+	.pmpro_membership_card-print h1,
+	.pmpro_membership_card-print p {
+		margin: 0 0 15px 0;
+		padding: 0;
+	}
+	.pmpro_membership_card-inner {
+		padding: 25px;
+	}
+	img.pmpro_membership_card_image {
+		border: none;
+		box-shadow: none;
+		float: right;
+	}
+	.pmpro_membership_card-print-md .pmpro_membership_card_image {
+		max-width: 200px;
+	}
+	.pmpro_membership_card-print-md img.pmpro_membership_card_image {
+		margin-bottom: 15px;
+	}
+	.pmpro_membership_card-print-sm,
+	.pmpro_membership_card-print-lg {
+		display: none;
+		visibility: hidden !important;
+	}
+	.pmpro_clear {
+		clear: both;
+	}
+	.pmpro_membership_card-inner .pmpro_membership_card-after p:last-of-type {
+		margin-bottom: 0;
+	}
+	.pmpro-qr-code-active .pmpro_membership_card-after img {
+		height: 100px;
+		width: 100px;
+	}
 	/* Print Styles */
 	@media print
 	{	
-		.page, .page .pmpro_membership_card #nav-below {visibility: hidden !important;}
-		.page .pmpro_membership_card {left: 2%; position: fixed; top: 2%; visibility: visible !important; width: 96%;}		
-		<?php if(!empty($print_small)) { ?>
-			.pmpro_membership_card-print-sm {display: block; float: right; visibility: visible !important; width: 42%;}
-			.pmpro_membership_card-print-sm img.pmpro_membership_card_image {margin-bottom: 5%; max-width: 110px !important; }
-			.pmpro_membership_card-print-sm .pmpro_membership_card-inner.qr_code_active .pmpro_membership_card-data, .pmpro_membership_card-print-sm .pmpro_membership_card-inner.qr_code_active .pmpro_membership_card-after { width: 100%; margin-left: 0px; }
+		.page, .page .pmpro_membership_card #nav-below {
+			visibility: hidden !important;
+		}
+		.page .pmpro_membership_card {
+			left: 1mm;
+			position: fixed;
+			top: 1mm;
+			visibility: visible !important;
+		}
+		.pmpro-qr-code-active .pmpro_membership_card-after img {
+			height: 40px;
+			width: 40px;
+		}
+		<?php if ( ! empty( $print_small ) ) { ?>
+			.pmpro_membership_card-print-sm {
+				display: block;
+				height: 54mm;
+				margin-bottom: 5mm;
+				overflow: hidden;
+				width: 86mm;
+				visibility: visible !important;
+			}
+			.pmpro_membership_card-print-sm .pmpro_membership_card-inner {
+				display: flex;
+				align-items: center;
+				height: 100%;
+				padding: 5mm;
+			}
+			.pmpro_membership_card-print-sm .pmpro_membership_card-inner * {
+				flex: 1;
+			}
+			.pmpro_membership_card-print-sm img.pmpro_membership_card_image {
+				margin-bottom: 5mm;
+				max-width: 18mm !important;
+			}
+			.pmpro_membership_card-print.pmpro_membership_card-print-sm h1 {
+				font-size: 16pt;
+				line-height: 20pt;
+				margin: 0;
+			}
+			.pmpro_membership_card-print.pmpro_membership_card-print-sm p {
+				font-size: 11pt;
+				line-height: 14pt;
+				margin: 2mm 0 0 0;
+			}
 		<?php } ?>		
 		<?php if(!empty($print_medium)) { ?>
-			.pmpro_membership_card-print-md {float: left; margin-bottom: 10%; visibility: visible !important; width: 48%;}
-			.pmpro_membership_card-print-md .pmpro_membership_card-inner {padding: 10% 5%;}
-			.pmpro_membership_card-print-md img.pmpro_membership_card_image {max-width: 150px !important; }
-			.pmpro_membership_card-print-md .pmpro_membership_card-inner.qr_code_active .pmpro_membership_card-data, .pmpro_membership_card-print-md .pmpro_membership_card-inner.qr_code_active .pmpro_membership_card-after { width: 100%; margin-left: 0px; }
+			.pmpro_membership_card-print-md {
+				height: 64mm;
+				margin-bottom: 5mm;
+				overflow: hidden;
+				width: 102mm;
+				visibility: visible !important;
+			}
+			.pmpro_membership_card-print-md .pmpro_membership_card-inner {
+				display: flex;
+				align-items: center;
+				height: 100%;
+				padding: 8mm;
+			}
+			.pmpro_membership_card-print-md .pmpro_membership_card-inner * {
+				flex: 1;
+			}
+			.pmpro_membership_card-print-md img.pmpro_membership_card_image {
+				margin-bottom: 5mm;
+				max-width: 24mm !important;
+			}
+			.pmpro_membership_card-print.pmpro_membership_card-print-md h1 {
+				font-size: 24pt;
+				line-height: 30pt;
+				margin: 0;
+			}
+			.pmpro_membership_card-print.pmpro_membership_card-print-md p {
+				font-size: 12pt;
+				line-height: 16pt;
+				margin: 2mm 0 0 0;
+			}
 		<?php } else { ?>
-			.pmpro_membership_card-print-md {display: none; }
+			.pmpro_membership_card-print-md {
+				display: none;
+			}
 		<?php } ?>
 		<?php if(!empty($print_large)) { ?>
-			.pmpro_membership_card-print-lg {clear: both; display: block; line-height: 26px; visibility: visible !important; width: 100%;}
-			.pmpro_membership_card-print-lg .pmpro_membership_card-inner {padding: 10% 5%;}
-			.pmpro_membership_card-print-lg img.pmpro_membership_card_image {max-width: 250px !important;}
-			.pmpro_membership_card-print-lg h1 {font-size: 60px; margin: 0 0 50px 0;}
-			.pmpro_membership_card-print-lg p {font-size: 22px; margin: 20px 0 0 0;}
+			.pmpro_membership_card-print-lg {
+				display: block;
+				height: 90mm;
+				overflow: hidden;
+				width: 143mm;
+				visibility: visible !important;
+			}
+			.pmpro_membership_card-print-lg .pmpro_membership_card-inner {
+				display: flex;
+				align-items: center;
+				height: 100%;
+				padding: 10mm;
+			}
+			.pmpro_membership_card-print-lg .pmpro_membership_card-inner * {
+				flex: 1;
+			}
+			.pmpro_membership_card-print-lg img.pmpro_membership_card_image {
+				margin-bottom: 5mm;
+				max-width: 40mm !important;
+			}
+			.pmpro_membership_card-print.pmpro_membership_card-print-lg h1 {
+				font-size: 28pt;
+				line-height: 32pt;
+				margin: 0;
+			}
+			.pmpro_membership_card-print.pmpro_membership_card-print-lg p {
+				font-size: 14pt;
+				line-height: 18pt;
+				margin: 5mm 0 0 0;
+			}
+			.pmpro_membership_card-print.pmpro_membership_card-print-lg .pmpro-qr-code-active .pmpro_membership_card-after img {
+				height: 60px;
+				width: 60px;
+			}
 		<?php } ?>
 	}
 </style>
@@ -71,52 +198,6 @@
 		else
 			$since = isset( $pmpro_membership_card_user->user_registered ) ? $pmpro_membership_card_user->user_registered : '';
 	?>
-	<div class="pmpro_membership_card-print pmpro_membership_card-print-md">
-		<div class="pmpro_membership_card-inner <?php do_action( 'pmpro_membership_card-extra_classes', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>">
-			<div class="pmpro_membership_card-data">
-				<h1>
-					<?php 
-						echo pmpro_membership_card_return_user_name( $pmpro_membership_card_user );
-					?>
-				</h1>		
-				<?php
-					if(!empty($featured_image))
-					{
-					?>
-					<img id="pmpro_membership_card_image" class="pmpro_membership_card_image" src="<?php echo esc_attr($featured_image);?>" border="0" />
-					<?php
-					}
-				?>	
-				<?php
-					if(!empty($since))
-					{
-					?>
-					<p id="pmpro_membership_card_member_since"><strong><?php _e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo apply_filters('pmpro_membership_card_since_date', date_i18n( get_option("date_format"), strtotime( $pmpro_membership_card_user->user_registered ) ), $pmpro_membership_card_user );?></p>
-					<?php
-					}
-				?>
-				
-				<?php if(function_exists("pmpro_hasMembershipLevel")) { ?>
-
-				<p><strong><?php _e("Level", 'pmpro-membership-card');?>:</strong>
-				<?php
-					pmpro_membership_card_output_levels_for_user( $pmpro_membership_card_user );
-				?>
-				</p>		
-				<p><strong><?php _e("Membership Expires", 'pmpro-membership-card');?>:</strong> 
-					<?php 
-						echo pmpro_membership_card_return_end_date( $pmpro_membership_card_user );
-					?>
-				</p>
-				<?php } ?>	
-				<?php if( has_action( 'pmpro_membership_card_after_card' ) ){ ?>
-					<div class="pmpro_membership_card-after">
-						<?php do_action( 'pmpro_membership_card_after_card', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>
-					</div>
-				<?php } ?>
-			</div>
-		</div><div class="pmpro_clear"></div>
-	</div> <!-- end pmpro_membership_card-print-md -->
 	<div class="pmpro_membership_card-print pmpro_membership_card-print-sm"<?php if(empty($print_small)) { ?> style="display: none;"<?php } ?>>
 		<div class="pmpro_membership_card-inner <?php do_action( 'pmpro_membership_card-extra_classes', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>">
 			<div class="pmpro_membership_card-data">
@@ -152,7 +233,7 @@
 					<?php 
 						echo pmpro_membership_card_return_end_date( $pmpro_membership_card_user );
 					?>
-				</p>				
+				</p>
 				<?php } ?>
 				<?php if( has_action( 'pmpro_membership_card_after_card' ) ){ ?>
 					<div class="pmpro_membership_card-after">
@@ -162,6 +243,52 @@
 			</div>
 		</div><div class="pmpro_clear"></div>
 	</div> <!-- end pmpro_membership_card-print-sm -->
+	<div class="pmpro_membership_card-print pmpro_membership_card-print-md">
+		<div class="pmpro_membership_card-inner <?php do_action( 'pmpro_membership_card-extra_classes', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>">
+			<div class="pmpro_membership_card-data">
+				<h1>
+					<?php 
+						echo pmpro_membership_card_return_user_name( $pmpro_membership_card_user );
+					?>
+				</h1>		
+				<?php
+					if(!empty($featured_image))
+					{
+					?>
+					<img id="pmpro_membership_card_image" class="pmpro_membership_card_image" src="<?php echo esc_attr($featured_image);?>" border="0" />
+					<?php
+					}
+				?>	
+				<?php
+					if(!empty($since))
+					{
+					?>
+					<p id="pmpro_membership_card_member_since"><strong><?php _e( 'Member Since', 'pmpro-membership-card' ); ?>:</strong> <?php echo apply_filters('pmpro_membership_card_since_date', date_i18n( get_option("date_format"), strtotime( $pmpro_membership_card_user->user_registered ) ), $pmpro_membership_card_user );?></p>
+					<?php
+					}
+				?>
+
+				<?php if(function_exists("pmpro_hasMembershipLevel")) { ?>
+
+				<p><strong><?php _e("Level", 'pmpro-membership-card');?>:</strong>
+				<?php
+					pmpro_membership_card_output_levels_for_user( $pmpro_membership_card_user );
+				?>
+				</p>
+				<p><strong><?php _e("Membership Expires", 'pmpro-membership-card');?>:</strong> 
+					<?php 
+						echo pmpro_membership_card_return_end_date( $pmpro_membership_card_user );
+					?>
+				</p>
+				<?php } ?>
+				<?php if( has_action( 'pmpro_membership_card_after_card' ) ){ ?>
+					<div class="pmpro_membership_card-after">
+						<?php do_action( 'pmpro_membership_card_after_card', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>
+					</div>
+				<?php } ?>
+			</div>
+		</div><div class="pmpro_clear"></div>
+	</div> <!-- end pmpro_membership_card-print-md -->
 	<div class="pmpro_membership_card-print pmpro_membership_card-print-lg"<?php if(empty($print_large)) { ?> style="display: none;"<?php } ?>>
 		<div class="pmpro_membership_card-inner <?php do_action( 'pmpro_membership_card-extra_classes', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>">
 			<div class="pmpro_membership_card-data">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-membership-card/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-membership-card/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adjusting the print sizes to be fixed card sizes using a normal credit card aspect ratio. The small size now prints at the size of a classic credit card.

![Screenshot 2023-12-16 at 1 48 45 PM](https://github.com/strangerstudios/pmpro-membership-card/assets/5312875/4c8d89a6-11ff-413d-9247-1c0fa7c73f85)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
ENHANCEMENT: Setting fixed print size for three card sizes in millimeters. 
