### PR TITLE
Add filter to change expiration dates on the membership card

### DIFF
--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -328,7 +328,7 @@ function pmpro_membership_card_return_end_date( $pmpro_membership_card_user ){
 
 	// Make sure the user exists.
 	if ( empty( $pmpro_membership_card_user ) ) {
-		return __( 'Never', 'pmpro-membership-card' );
+		return esc_html__( 'Never', 'pmpro-membership-card' );
 	}
 
 	$furthest_enddate = null;
@@ -338,11 +338,19 @@ function pmpro_membership_card_return_end_date( $pmpro_membership_card_user ){
 		}
 	}
 
-	if( ! empty( $furthest_enddate ) )
-		return date_i18n( get_option('date_format'), $furthest_enddate );
-	else
-		return __('Never', 'pmpro-membership-card');
+	if ( ! empty( $furthest_enddate ) ) {
+		$date = date_i18n( get_option( 'date_format' ), $furthest_enddate );
+	} else {
+		$date = esc_html__( 'Never', 'pmpro-membership-card' );
+	}
 
+	/**
+	 * Filter the end date for the membership card.
+	 * @param $date The date to display.
+	 * @param $pmpro_membership_card_user The membership user.
+	 * @since TBD
+	 */
+	return apply_filters( 'pmpro_membership_card_member_end_date', $date, $pmpro_membership_card_user );
 }
 
 /**


### PR DESCRIPTION
* ENHANCEMENT: Added filter 'pmpro_membership_card_member_end_date' to allow developers to adjust the output of the expiration date for the membership card. It takes the $date and $pmpro_membership_card_user respectively.

Note: This also improves the sanitization on the output to use escape functions.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-membership-card/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-membership-card/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves [54.](https://github.com/strangerstudios/pmpro-membership-card/issues/54)

### How to test the changes in this Pull Request:

After pulling this code, you may use the gist below to display the date like June 10, 2025. (Please make sure that your default WordPress date is a different format or tweak the gist below further).

[Code example](https://gist.github.com/andrewlimaza/02725da1165b845a16baaf9cf6e887d9)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
