### PR TITLE
Avatar functionality to membership card

### DIFF
--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -111,7 +111,8 @@ function pmpro_membership_card_shortcode($atts, $content=null, $code="")
 	extract(shortcode_atts(array(
 		'print_size' => 'all',
 		'qr_code' => 'false',
-		'qr_data' => 'ID' // Accepts ID, email and level
+		'qr_data' => 'ID', // Accepts ID, email and level
+		'show_avatar' => 'false'
 	), $atts));
 
 	$print_sizes = explode(",", $print_size);

--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -22,7 +22,11 @@
 	else
 		$print_large = false;
 
-
+	if ( $show_avatar === 'false' ) {
+		$show_avatar = false;
+	} else {
+		$show_avatar = true;
+	}
 ?>
 <style>
 	/* Hide any thumbnail that might be on the page. */
@@ -208,6 +212,24 @@
 	<div class="pmpro_membership_card-print pmpro_membership_card-print-sm"<?php if(empty($print_small)) { ?> style="display: none;"<?php } ?>>
 		<div class="pmpro_membership_card-inner <?php do_action( 'pmpro_membership_card-extra_classes', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>">
 			<div class="pmpro_membership_card-data">
+				<?php
+					if ( function_exists( 'get_avatar' ) && $show_avatar !== false ) {
+						$avatar_args = apply_filters( 'pmpro_membership_card_avatar_args', 
+						array( 
+							'size' => 150,
+							'default' => 'wavatar',
+							'alt' => pmpro_membership_card_return_user_name( $pmpro_membership_card_user ) . ' avatar',
+							'args' => array( 
+								'class' => 'pmpro_membership_card_avatar'
+								)
+							) 
+						);
+						$avatar = get_avatar( $pmpro_membership_card_user->ID, $avatar_args['size'], $avatar_args['default'], $avatar_args['alt'], $avatar_args['args'] );
+						if( ! empty( $avatar ) ) {
+							?><div id="pmpro_membership_card_avatar"><?php echo $avatar; ?></div><?php
+						}
+					}
+				?>
 				<h1>
 					<?php 
 						echo pmpro_membership_card_return_user_name( $pmpro_membership_card_user );
@@ -253,6 +275,24 @@
 	<div class="pmpro_membership_card-print pmpro_membership_card-print-md">
 		<div class="pmpro_membership_card-inner <?php do_action( 'pmpro_membership_card-extra_classes', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>">
 			<div class="pmpro_membership_card-data">
+				<?php
+					if ( function_exists( 'get_avatar' ) && $show_avatar !== false ) {
+						$avatar_args = apply_filters( 'pmpro_membership_card_avatar_args', 
+						array( 
+							'size' => 150,
+							'default' => 'wavatar',
+							'alt' => pmpro_membership_card_return_user_name( $pmpro_membership_card_user ) . ' avatar',
+							'args' => array( 
+								'class' => 'pmpro_membership_card_avatar'
+								)
+							) 
+						);
+						$avatar = get_avatar( $pmpro_membership_card_user->ID, $avatar_args['size'], $avatar_args['default'], $avatar_args['alt'], $avatar_args['args'] );
+						if( ! empty( $avatar ) ) {
+							?><div id="pmpro_membership_card_avatar"><?php echo $avatar; ?></div><?php
+						}
+					}
+				?>
 				<h1>
 					<?php 
 						echo pmpro_membership_card_return_user_name( $pmpro_membership_card_user );
@@ -299,6 +339,24 @@
 	<div class="pmpro_membership_card-print pmpro_membership_card-print-lg"<?php if(empty($print_large)) { ?> style="display: none;"<?php } ?>>
 		<div class="pmpro_membership_card-inner <?php do_action( 'pmpro_membership_card-extra_classes', $pmpro_membership_card_user, $print_sizes, $qr_code, $qr_data ); ?>">
 			<div class="pmpro_membership_card-data">
+				<?php
+					if ( function_exists( 'get_avatar' ) && $show_avatar !== false ) {
+						$avatar_args = apply_filters( 'pmpro_membership_card_avatar_args', 
+						array( 
+							'size' => 150,
+							'default' => 'wavatar',
+							'alt' => pmpro_membership_card_return_user_name( $pmpro_membership_card_user ) . ' avatar',
+							'args' => array( 
+								'class' => 'pmpro_membership_card_avatar'
+								)
+							) 
+						);
+						$avatar = get_avatar( $pmpro_membership_card_user->ID, $avatar_args['size'], $avatar_args['default'], $avatar_args['alt'], $avatar_args['args'] );
+						if( ! empty( $avatar ) ) {
+							?><div id="pmpro_membership_card_avatar"><?php echo $avatar; ?></div><?php
+						}
+					}
+				?>
 				<h1>
 					<?php 
 						echo pmpro_membership_card_return_user_name( $pmpro_membership_card_user );

--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -258,7 +258,7 @@
 					pmpro_membership_card_output_levels_for_user( $pmpro_membership_card_user );
 				?>
 				</p>		
-				<p><strong><?php _e("Membership Expires", 'pmpro-membership-card');?>:</strong> 
+				<p id="pmpro_membership_card_member_end_date"><strong><?php esc_html_e("Membership Expires", 'pmpro-membership-card');?>:</strong> 
 					<?php 
 						echo pmpro_membership_card_return_end_date( $pmpro_membership_card_user );
 					?>


### PR DESCRIPTION
* ENHANCEMENT: Add the ability to show_avatar attribute to show the members avatar.

* ENHANCEMENT: New filter added to give you even more control over the avatar settings - pmpro_membership_card_avatar_args (takes an array of values that passes through to the get_avatar function).

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-membership-card/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-membership-card/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves [19](https://github.com/strangerstudios/pmpro-membership-card/issues/19).

### How to test the changes in this Pull Request:

1. Try the shortcode `[pmpro_membership_card show_avatar="true"]`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


