### PR TITLE
Enhancement: Improve debug logging condition

### DIFF
--- a/class.pmpro_posts_by_content.php
+++ b/class.pmpro_posts_by_content.php
@@ -34,8 +34,9 @@ class pmpro_posts_by_content
         // isset( $args['like'] ) and self::$like = (bool) $like;
         $posts = get_posts( $args);
 
-        if( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG )
-            error_log("pmpro_posts_by_content: " . print_r($posts, true));
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( 'pmpro_posts_by_content: ' . print_r( $posts, true ) );
+        }
 
         return $posts;
     }
@@ -44,8 +45,9 @@ class pmpro_posts_by_content
     {
         remove_filter('posts_where', array(__CLASS__, 'where_filter'));
 
-        if( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG )
-            error_log("pmpro_posts_by_content: " . print_r( $where, true ));
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( 'pmpro_posts_by_content: ' . print_r( $where, true ) );
+        }
 
         global $wpdb;
         $like = self::$like ? 'LIKE' : 'NOT LIKE';
@@ -58,8 +60,9 @@ class pmpro_posts_by_content
 
         $new_where = "{$where} AND post_content {$like} {$extra}";
 
-        if( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG )
-            error_log("pmpro_posts_by_content: " . print_r($new_where, true));
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( 'pmpro_posts_by_content: ' . print_r( $new_where, true ) );
+        }
 
         return $new_where;
     }


### PR DESCRIPTION
Check if `WP_DEBUG` is defined and `true` instead of checking `WP_DEBUG_LOG`.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-membership-card/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-membership-card/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Check if `WP_DEBUG` is defined and `true` instead of checking `WP_DEBUG_LOG` as this may sometimes return true if a file location was set as this constant's value instead of a boolean which may lead to error logging in the PHP Log file even if WP_DEBUG` is set to `false`

### How to test the changes in this Pull Request:

1. Enable error logging in the server's `php.ini` configuration.
2. Set `WP_DEBUG` to `false` and set a file location for `WP_DEBUG_LOG`, e.g. `define( 'WP_DEBUG_LOG', '/var/www/my-wp-debug-log.log' );`.
3. Navigate to the Membership Card page as a logged-in member.
4. Confirm that no log entries were made in the custom WordPress debug log file or the server's PHP error log file.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement: Improve debug logging condition
