### PR TITLE
[BUGFIXING] Unable to translate the Print link

### DIFF
--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -196,7 +196,7 @@
 		<?php } ?>
 	}
 </style>
-<a class="pmpro_a-print" href="javascript:window.print()">Print</a>
+<a class="pmpro_a-print" href="javascript:window.print()"><?php esc_html_e( 'Print', 'pmpro-membership-card' ); ?></a>
 <div class="pmpro_membership_card">
 	<?php 
 		$featured_image = wp_get_attachment_url( get_post_thumbnail_id($post->ID) ); 


### PR DESCRIPTION
 * Add link text to the translation domain

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-membership-card/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-membership-card/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Make hardcoded Print text part of the plugin domain.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves #60 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
