### PR TITLE
Show expirations with levels

### DIFF
--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -369,14 +369,21 @@ function pmpro_membership_card_return_end_date( $pmpro_membership_card_user ){
 
 	// Get the level names.
 	$level_names = array_map( function( $level, $pmpro_membership_card_user ) {
-		if ( empty( $level->enddate ) ) {
+		// Get the expiration date to maybe show.
+		$expiration_date_text = '';
+		if ( function_exists( 'pmpro_get_membership_expiration_text' ) ) {
+			$expiration_date_text = pmpro_get_membership_expiration_text( $level, $pmpro_membership_card_user, '' );
+		} else {
+			if ( ! empty( $level->enddate ) ) {
+				$expiration_date_text = date_i18n( get_option('date_format'), $level->enddate );
+			}
+		}
+
+		// Return the level name and expiration date if it exists.
+		if ( empty( $expiration_date_text ) ) {
 			return $level->name;
 		} else {
-			if ( function_exists( 'pmpro_get_membership_expiration_text' ) ) {
-				return $level->name . ' <em>(' . pmpro_get_membership_expiration_text( $level, $pmpro_membership_card_user  ) . ')</em>';
-			} else {
-				return $level->name . ' <em>(' . sprintf( __( 'Expires %s', 'pmpro-membership-card' ), date_i18n( get_option('date_format'), $level->enddate ) ) . ')</em>';
-			}
+			return $level->name . ' <em>(' . sprintf( esc_html__( 'Expires %s', 'pmpro-membership-card' ), esc_html( $expiration_date_text ) ) . ')</em>';
 		}
 	}, $levels, array( $pmpro_membership_card_user ) );
 	sort( $level_names );
@@ -388,11 +395,10 @@ function pmpro_membership_card_return_end_date( $pmpro_membership_card_user ){
 		$display .= '<li>' . implode( '</li><li>', $level_names ) . '</li>';
 		$display .= '</ul>';
 	} else {
-		$level_name = current( $level_names );
-		$display = esc_html( $level_name );
+		$display = current( $level_names );
 	}
 
-	echo apply_filters( 'pmpro_membership_card_mmpu_output', $display, $levels, $pmpro_membership_card_user );
+	echo wp_kses_post( apply_filters( 'pmpro_membership_card_mmpu_output', $display, $levels, $pmpro_membership_card_user ) );
 }
 
 /**

--- a/pmpro-membership-card.php
+++ b/pmpro-membership-card.php
@@ -323,8 +323,12 @@ function pmpro_membership_card_return_user_name( $pmpro_membership_card_user ){
 
 /**
  * Returns the members most distant expiration date for their memberships.
+ *
+ * @deprecated TBD
  */
 function pmpro_membership_card_return_end_date( $pmpro_membership_card_user ){
+	// Show deprecation message.
+	_deprecated_function( __FUNCTION__, 'TBD', 'pmpro_membership_card_output_levels_for_user' );
 
 	// Make sure the user exists.
 	if ( empty( $pmpro_membership_card_user ) ) {
@@ -364,7 +368,17 @@ function pmpro_membership_card_return_end_date( $pmpro_membership_card_user ){
 	}
 
 	// Get the level names.
-	$level_names = wp_list_pluck( $levels, 'name' );
+	$level_names = array_map( function( $level, $pmpro_membership_card_user ) {
+		if ( empty( $level->enddate ) ) {
+			return $level->name;
+		} else {
+			if ( function_exists( 'pmpro_get_membership_expiration_text' ) ) {
+				return $level->name . ' <em>(' . pmpro_get_membership_expiration_text( $level, $pmpro_membership_card_user  ) . ')</em>';
+			} else {
+				return $level->name . ' <em>(' . sprintf( __( 'Expires %s', 'pmpro-membership-card' ), date_i18n( get_option('date_format'), $level->enddate ) ) . ')</em>';
+			}
+		}
+	}, $levels, array( $pmpro_membership_card_user ) );
 	sort( $level_names );
 
 	// Output the level names.

--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -235,11 +235,6 @@
 				<?php
 					pmpro_membership_card_output_levels_for_user( $pmpro_membership_card_user );
 				?>
-				</p>		
-				<p><strong><?php _e("Membership Expires", 'pmpro-membership-card');?>:</strong> 
-					<?php 
-						echo pmpro_membership_card_return_end_date( $pmpro_membership_card_user );
-					?>
 				</p>
 				<?php } ?>
 				<?php if( has_action( 'pmpro_membership_card_after_card' ) ){ ?>
@@ -282,11 +277,6 @@
 					pmpro_membership_card_output_levels_for_user( $pmpro_membership_card_user );
 				?>
 				</p>
-				<p><strong><?php _e("Membership Expires", 'pmpro-membership-card');?>:</strong> 
-					<?php 
-						echo pmpro_membership_card_return_end_date( $pmpro_membership_card_user );
-					?>
-				</p>
 				<?php } ?>
 				<?php if( has_action( 'pmpro_membership_card_after_card' ) ){ ?>
 					<div class="pmpro_membership_card-after">
@@ -327,12 +317,7 @@
 				<?php
 					pmpro_membership_card_output_levels_for_user( $pmpro_membership_card_user );
 				?>
-				</p>		
-				<p><strong><?php _e("Membership Expires", 'pmpro-membership-card');?>:</strong> 
-					<?php 
-						echo pmpro_membership_card_return_end_date( $pmpro_membership_card_user );
-					?>
-				</p>				
+				</p>			
 				<?php } ?>
 				<?php if( has_action( 'pmpro_membership_card_after_card' ) ){ ?>
 					<div class="pmpro_membership_card-after">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-membership-card/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-membership-card/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Alternative to #55
Resolves #54 

Shows expiration dates with each level instead of one expiration date for all levels. Since PMPro v3.0 or so, the expiration dates should also be filterable.
Before:
![Screenshot 2025-03-06 at 1 55 16 PM](https://github.com/user-attachments/assets/3442e573-f8c9-4f09-a294-2769d8c8ce62)

After:
![Screenshot 2025-03-06 at 2 20 18 PM](https://github.com/user-attachments/assets/0b7b37be-ba1b-4e9f-9150-3b14f9ae606b)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
