### PR TITLE
Make QR code resizable

### DIFF
--- a/templates/membership-card.php
+++ b/templates/membership-card.php
@@ -73,10 +73,6 @@
 	.pmpro_membership_card-inner .pmpro_membership_card-after p:last-of-type {
 		margin-bottom: 0;
 	}
-	.pmpro-qr-code-active .pmpro_membership_card-after img {
-		height: 100px;
-		width: 100px;
-	}
 	/* Print Styles */
 	@media print
 	{	


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-membership-card/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-membership-card/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Remove QR code fixed size CSS.

Resolves #59 

### How to test the changes in this Pull Request:

1. Add QR code to membership card.
2. Use [pmpro_membership_card_qr_code_size](https://www.paidmembershipspro.com/adjust-the-size-of-the-qr-code-on-the-membership-card/) filter to adjust the size of your QR code.
3. Size changes if PR is applied.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> QR code can be resized using the `pmpro_membership_card_qr_code_size` filter.
